### PR TITLE
Hotfix incorrect brake amount

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 cmake*/
 CMakeLists.txt
 settings.json
+./vscode/ipch/*
+./vscode/ipch

--- a/code/src/qik_2s12v10.cpp
+++ b/code/src/qik_2s12v10.cpp
@@ -115,17 +115,21 @@ namespace r2d2::moving_platform {
     }
 
     void qik_2s12v10_c::brake(const int8_t brake_amount) {
-        usart_bus << qik_2s12v10_registers::set_motor_m0_brake << brake_amount;
-        usart_bus << qik_2s12v10_registers::set_motor_m1_brake << brake_amount;
+        usart_bus << qik_2s12v10_registers::set_motor_m0_brake
+                  << static_cast<char>(brake_amount);
+        usart_bus << qik_2s12v10_registers::set_motor_m1_brake
+                  << static_cast<char>(brake_amount);
     }
 
     void qik_2s12v10_c::brake_m0(const int8_t brake_amount) {
-        usart_bus << qik_2s12v10_registers::set_motor_m0_brake << brake_amount;
+        usart_bus << qik_2s12v10_registers::set_motor_m0_brake
+                  << static_cast<char>(brake_amount);
         set_m0_speed(0);
     }
 
     void qik_2s12v10_c::brake_m1(const int8_t brake_amount) {
-        usart_bus << qik_2s12v10_registers::set_motor_m1_brake << brake_amount;
+        usart_bus << qik_2s12v10_registers::set_motor_m1_brake
+                  << static_cast<char>(brake_amount);
         set_m1_speed(0);
     }
 


### PR DESCRIPTION
There is a conversion error from int8_t to character in the brake functions of the qik_2s12v10 controller class.
The static cast fixes that error.